### PR TITLE
cleaning up report folder before running tests

### DIFF
--- a/spock-0.7/src/main/java/ru/yandex/qatools/allure/spock/AllureSpockConfig.java
+++ b/spock-0.7/src/main/java/ru/yandex/qatools/allure/spock/AllureSpockConfig.java
@@ -1,0 +1,24 @@
+package ru.yandex.qatools.allure.spock;
+
+import ru.yandex.qatools.properties.PropertyLoader;
+import ru.yandex.qatools.properties.annotations.Property;
+import ru.yandex.qatools.properties.annotations.Resource;
+
+@Resource.Classpath("allure.properties")
+public class AllureSpockConfig {
+
+    @Property("allure.spock.results.delete")
+    private Boolean deleteAllureTestReportResult = true;
+
+    public Boolean isDeleteAllureTestReportResult() {
+        return deleteAllureTestReportResult;
+    }
+
+    public AllureSpockConfig() {
+        PropertyLoader.populate(this);
+    }
+
+    public static AllureSpockConfig newInstance() {
+        return new AllureSpockConfig();
+    }
+}

--- a/spock-0.7/src/main/java/ru/yandex/qatools/allure/spock/AllureSpockExtension.java
+++ b/spock-0.7/src/main/java/ru/yandex/qatools/allure/spock/AllureSpockExtension.java
@@ -2,6 +2,7 @@ package ru.yandex.qatools.allure.spock;
 
 import org.spockframework.runtime.extension.IGlobalExtension;
 import org.spockframework.runtime.model.SpecInfo;
+import ru.yandex.qatools.allure.config.AllureConfig;
 
 /**
  * @author Dmitry Baev charlie@yandex-team.ru
@@ -9,8 +10,18 @@ import org.spockframework.runtime.model.SpecInfo;
  */
 public class AllureSpockExtension implements IGlobalExtension {
 
+    private static boolean inited = false;
+
     @Override
     public void visitSpec(SpecInfo spec) {
+        if (!inited) {
+            doInit();
+            inited = true;
+        }
         spec.addListener(new SpockRunListener());
+    }
+
+    private void doInit() {
+        TargetDirCleaner.deleteTestReports(AllureConfig.newInstance().getResultsDirectory());
     }
 }

--- a/spock-0.7/src/main/java/ru/yandex/qatools/allure/spock/TargetDirCleaner.java
+++ b/spock-0.7/src/main/java/ru/yandex/qatools/allure/spock/TargetDirCleaner.java
@@ -1,0 +1,34 @@
+package ru.yandex.qatools.allure.spock;
+
+import ru.yandex.qatools.allure.config.AllureConfig;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.regex.Pattern;
+
+public class TargetDirCleaner {
+
+    public static void deleteTestReports(File dir) {
+        if (AllureSpockConfig.newInstance().isDeleteAllureTestReportResult()) {
+
+            if (!dir.exists()) return;
+
+            String testSuiteFileRegex = AllureConfig.newInstance().getTestSuiteFileRegex();
+            final Pattern pattern = Pattern.compile(testSuiteFileRegex);
+
+            File[] files = dir.listFiles(new FilenameFilter() {
+                @Override
+                public boolean accept(File dir, String name) {
+                    return pattern.matcher(name).matches();
+                }
+            });
+
+            if (files == null) return;
+
+            for (File file : files) {
+                file.delete();
+            }
+        }
+    }
+
+}

--- a/spock-1.0/src/main/java/ru/yandex/qatools/allure/spock/AllureSpockConfig.java
+++ b/spock-1.0/src/main/java/ru/yandex/qatools/allure/spock/AllureSpockConfig.java
@@ -1,0 +1,24 @@
+package ru.yandex.qatools.allure.spock;
+
+import ru.yandex.qatools.properties.PropertyLoader;
+import ru.yandex.qatools.properties.annotations.Property;
+import ru.yandex.qatools.properties.annotations.Resource;
+
+@Resource.Classpath("allure.properties")
+public class AllureSpockConfig {
+
+    @Property("allure.spock.results.delete")
+    private Boolean deleteAllureTestReportResult = true;
+
+    public Boolean isDeleteAllureTestReportResult() {
+        return deleteAllureTestReportResult;
+    }
+
+    public AllureSpockConfig() {
+        PropertyLoader.populate(this);
+    }
+
+    public static AllureSpockConfig newInstance() {
+        return new AllureSpockConfig();
+    }
+}

--- a/spock-1.0/src/main/java/ru/yandex/qatools/allure/spock/AllureSpockExtension.java
+++ b/spock-1.0/src/main/java/ru/yandex/qatools/allure/spock/AllureSpockExtension.java
@@ -2,12 +2,18 @@ package ru.yandex.qatools.allure.spock;
 
 import org.spockframework.runtime.extension.AbstractGlobalExtension;
 import org.spockframework.runtime.model.SpecInfo;
+import ru.yandex.qatools.allure.config.AllureConfig;
 
 /**
  * @author Dmitry Baev charlie@yandex-team.ru
  *         Date: 24.06.14
  */
 public class AllureSpockExtension extends AbstractGlobalExtension {
+
+    @Override
+    public void start() {
+        TargetDirCleaner.deleteTestReports(AllureConfig.newInstance().getResultsDirectory());
+    }
 
     @Override
     public void visitSpec(SpecInfo spec) {

--- a/spock-1.0/src/main/java/ru/yandex/qatools/allure/spock/TargetDirCleaner.java
+++ b/spock-1.0/src/main/java/ru/yandex/qatools/allure/spock/TargetDirCleaner.java
@@ -1,0 +1,34 @@
+package ru.yandex.qatools.allure.spock;
+
+import ru.yandex.qatools.allure.config.AllureConfig;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.regex.Pattern;
+
+public class TargetDirCleaner {
+
+    public static void deleteTestReports(File dir) {
+        if (AllureSpockConfig.newInstance().isDeleteAllureTestReportResult()) {
+
+            if (!dir.exists()) return;
+
+            String testSuiteFileRegex = AllureConfig.newInstance().getTestSuiteFileRegex();
+            final Pattern pattern = Pattern.compile(testSuiteFileRegex);
+
+            File[] files = dir.listFiles(new FilenameFilter() {
+                @Override
+                public boolean accept(File dir, String name) {
+                    return pattern.matcher(name).matches();
+                }
+            });
+
+            if (files == null) return;
+
+            for (File file : files) {
+                file.delete();
+            }
+        }
+    }
+
+}

--- a/spock-1.0/src/test/groovy/ru/yandex/qatools/allure/spock/TargetDirCleanerSpec.groovy
+++ b/spock-1.0/src/test/groovy/ru/yandex/qatools/allure/spock/TargetDirCleanerSpec.groovy
@@ -1,0 +1,39 @@
+package ru.yandex.qatools.allure.spock
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class TargetDirCleanerSpec extends Specification {
+
+	@Rule
+	TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+	def "allure report directory is cleaned up"() {
+		when:
+			File targetDir = temporaryFolder.newFolder("allure-report")
+			ArrayList files = [
+					new File(targetDir, "01410c3e-0bc9-42ed-878b-e695395c4b05-testsuite.xml"),
+					new File(targetDir, "16c54e03-9e68-4e3b-8860-fdca670ab1d1-testsuite.xml")
+			]
+			files*.createNewFile()
+
+		then:
+			files*.exists()
+
+		when:
+			TargetDirCleaner.deleteTestReports(targetDir)
+
+		then:
+			files*.exists() == [false, false]
+	}
+
+	def "no error when report folder does not exist"() {
+
+		when:
+			TargetDirCleaner.deleteTestReports(new File("not/exists"))
+
+		then:
+			true
+	}
+}


### PR DESCRIPTION
This one just delete test report files from allure report folder before next test run.
It is needed bcoz Grails do not clean targed folder on 'clean'