### PR TITLE
#6 Stabilize spock-1.0 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>Allure Spock Adapter parent</name>
 
     <properties>
-        <allure.version>1.4.1</allure.version>
+        <allure.version>1.4.15</allure.version>
         <compiler.version>1.7</compiler.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gmaven-plugin.version>1.4</gmaven-plugin.version>

--- a/spock-1.0/pom.xml
+++ b/spock-1.0/pom.xml
@@ -15,14 +15,14 @@
     <name>Allure Spock 1.0 Adaptor</name>
 
     <properties>
-        <groovy.version>2.1.5</groovy.version>
+        <groovy.version>2.4.4</groovy.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.0-SNAPSHOT</version>
+            <version>1.0-groovy-2.4</version>
         </dependency>
 
         <!-- test dependencies  -->

--- a/spock-1.0/src/test/groovy/ru/yandex/qatools/allure/spock/SpockRunListenerSpec.groovy
+++ b/spock-1.0/src/test/groovy/ru/yandex/qatools/allure/spock/SpockRunListenerSpec.groovy
@@ -55,7 +55,7 @@ class SpockRunListenerSpec extends Specification {
 			1 * allure.fire({ TestSuiteStartedEvent event ->
 				assert event.name == "SimpleAnnotatedSpecification"
 				assert event.title == "Simple Specification"
-				assert event.description.value == "Simple Specification used for allure sock extension"
+				assert event.description.value == "Simple Specification used for allure spock extension"
 				true
 			})
 	}


### PR DESCRIPTION
Previously it was a SNAPSHOT version which wouldn't allow releasing
the artifacts to Central Nexus.

Additionally, version of Allure was updated to 1.4.15, though ideally
we should update it to 2.2, but I don't know if this transition is as
simple just changing the version.